### PR TITLE
Microsoft.GitCredentialManagerCore: update to 2.0.567

### DIFF
--- a/manifests/m/Microsoft/GitCredentialManagerCore/2.0.567/Microsoft.GitCredentialManagerCore.yaml
+++ b/manifests/m/Microsoft/GitCredentialManagerCore/2.0.567/Microsoft.GitCredentialManagerCore.yaml
@@ -1,0 +1,16 @@
+PackageVersion: 2.0.567
+PackageName: Microsoft Git Credential Manager Core
+Publisher: Microsoft
+Moniker: microsoft-git-credential-manager-core
+PackageUrl: https://aka.ms/gcmcore
+License: Copyright (C) Microsoft Corporation
+ShortDescription: |
+  Git Credential Manager Core Setup
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/microsoft/Git-Credential-Manager-Core/releases/download/v2.0.567/gcmcoreuser-win-x86-2.0.567.18224.exe
+  InstallerType: inno
+  InstallerSha256: 1985df0ac94deb0c26ba0e570055caed128c9baabc4c664b9ce822f8c10caa03
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.0.0


### PR DESCRIPTION
Creating manifest for new release of Microsoft.GitCredentialManagerCore (version 2.0.567)